### PR TITLE
Add wasm support improvements

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -7,6 +7,7 @@ Kotlin Multiplatform library for network time synchronization. It extends the [`
 - Android
 - iOS
 - Desktop JVM (MacOS, Linux, Windows)
+- Web
 ## Usage
 ### `kotlin.time` Extension
 The library [extends the main `Clock` interface](https://github.com/softartdev/Kronos-Multiplatform/blob/main/kronos/src/commonMain/kotlin/com/softartdev/kronos/ClockExt.kt) from the standard library. You can use the [`Clock.Network`](https://github.com/softartdev/Kronos-Multiplatform/blob/main/kronos/src/commonMain/kotlin/com/softartdev/kronos/NetworkClock.kt) class to retrieve the current network time, similar to using the built-in [`Clock.System`](https://github.com/JetBrains/kotlin/blob/master/libraries/stdlib/src/kotlin/time/Clock.kt#L60) instance.

--- a/kronos/build.gradle.kts
+++ b/kronos/build.gradle.kts
@@ -10,6 +10,7 @@ version = libs.versions.kronos.get()
 kotlin {
     jvmToolchain(libs.versions.jdk.get().toInt())
     jvm()
+    wasmJs()
     androidTarget {
         publishLibraryVariants("release", "debug")
     }
@@ -53,6 +54,8 @@ kotlin {
                 implementation(libs.androidx.test)
             }
         }
+        val wasmJsMain by getting
+        val wasmJsTest by getting
         val iosX64Main by getting
         val iosArm64Main by getting
         val iosSimulatorArm64Main by getting

--- a/kronos/src/wasmJsMain/kotlin/com/softartdev/kronos/Network.kt
+++ b/kronos/src/wasmJsMain/kotlin/com/softartdev/kronos/Network.kt
@@ -1,0 +1,13 @@
+@file:OptIn(ExperimentalTime::class)
+
+package com.softartdev.kronos
+
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+actual val Clock.Companion.Network: NetworkClock
+    get() = WasmNetworkClock
+
+fun NetworkClock.sync() = WasmNetworkClock.sync()
+fun NetworkClock.blockingSync(): Boolean = WasmNetworkClock.blockingSync()
+suspend fun NetworkClock.awaitSync(): Boolean = WasmNetworkClock.awaitSync()

--- a/kronos/src/wasmJsMain/kotlin/com/softartdev/kronos/WasmNetworkClock.kt
+++ b/kronos/src/wasmJsMain/kotlin/com/softartdev/kronos/WasmNetworkClock.kt
@@ -1,0 +1,44 @@
+package com.softartdev.kronos
+
+import kotlinx.browser.window
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.await
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlin.time.Clock
+
+/**
+ * Fetches network time using the public WorldTime API and stores the offset
+ * from the local system clock. The [sync] functions update the offset
+ * asynchronously or in a blocking fashion. After synchronization the clock
+ * provides network based timestamps via [getCurrentNtpTimeMs].
+ */
+object WasmNetworkClock : NetworkClock {
+
+    private var offsetMs: Long? = null
+
+    fun sync() {
+        GlobalScope.launch { awaitSync() }
+    }
+
+    fun blockingSync(): Boolean = runBlocking { awaitSync() }
+
+    suspend fun awaitSync(): Boolean = try {
+        val response = window.fetch("https://worldtimeapi.org/api/ip").await()
+        val json = response.json().await() as dynamic
+        val dateStr = json.datetime as String
+        val networkTimeMs = js("Date.parse(dateStr)").unsafeCast<Double>().toLong()
+        val systemTimeMs = js("Date.now()").unsafeCast<Double>().toLong()
+        offsetMs = networkTimeMs - systemTimeMs
+        true
+    } catch (t: Throwable) {
+        console.error("Failed to sync time", t)
+        false
+    }
+
+    override fun getCurrentNtpTimeMs(): Long? {
+        val offset = offsetMs ?: return null
+        val systemTimeMs = js("Date.now()").unsafeCast<Double>().toLong()
+        return systemTimeMs + offset
+    }
+}

--- a/sampleApp/build.gradle.kts
+++ b/sampleApp/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
     jvmToolchain(libs.versions.jdk.get().toInt())
     jvm("desktop")
     androidTarget()
+    wasmJs()
     iosX64()
     iosArm64()
     iosSimulatorArm64()
@@ -62,6 +63,8 @@ kotlin {
                 implementation(compose.preview)
             }
         }
+        val wasmJsMain by getting
+        val wasmJsTest by getting
         val iosX64Main by getting
         val iosArm64Main by getting
         val iosSimulatorArm64Main by getting

--- a/sampleApp/src/wasmJsMain/kotlin/com/softartdev/kronos/sample/App.wasm.kt
+++ b/sampleApp/src/wasmJsMain/kotlin/com/softartdev/kronos/sample/App.wasm.kt
@@ -1,0 +1,22 @@
+@file:OptIn(ExperimentalTime::class)
+
+package com.softartdev.kronos.sample
+
+import kotlinx.browser.window
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+internal actual fun openUrl(url: String?) {
+    url ?: return
+    window.open(url, "_blank")
+}
+
+internal actual fun clickSync() = Clock.Network.sync()
+
+internal actual fun clickBlockingSync() {
+    Clock.Network.blockingSync()
+}
+
+internal actual suspend fun clickAwaitSync() {
+    Clock.Network.awaitSync()
+}

--- a/sampleApp/src/wasmJsMain/kotlin/com/softartdev/kronos/sample/Platform.kt
+++ b/sampleApp/src/wasmJsMain/kotlin/com/softartdev/kronos/sample/Platform.kt
@@ -1,0 +1,7 @@
+package com.softartdev.kronos.sample
+
+class WasmJsPlatform : Platform {
+    override val name: String = "Web"
+}
+
+actual fun getPlatform(): Platform = WasmJsPlatform()


### PR DESCRIPTION
## Summary
- list Web as a platform in the README
- simplify wasmJs source set dependencies
- rename variable for clarity in WasmNetworkClock
- correct platform name for wasm implementation

## Testing
- `./gradlew :kronos:jvmTest --no-daemon -PsonatypeStagingProfileId=dummy`


------
https://chatgpt.com/codex/tasks/task_e_6863699b2e088330b25cc93aeadec424