### PR TITLE
Add wasmJs coroutines dependency

### DIFF
--- a/kronos/build.gradle.kts
+++ b/kronos/build.gradle.kts
@@ -53,6 +53,11 @@ kotlin {
                 implementation(libs.androidx.test)
             }
         }
+        val wasmJsMain by getting {
+            dependencies {
+                implementation(libs.kotlinx.coroutines.core)
+            }
+        }
         val iosX64Main by getting
         val iosArm64Main by getting
         val iosSimulatorArm64Main by getting


### PR DESCRIPTION
## Summary
- update `kronos/build.gradle.kts` to include a dependency block for `wasmJsMain`

## Testing
- `./gradlew build --no-daemon` *(fails: Cannot get property 'sonatypeStagingProfileId')*

------
https://chatgpt.com/codex/tasks/task_e_6863c11817b883309ca21538671ff3f0